### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/src/pages/demos/animated-bar/animated-bar.md
+++ b/docs/src/pages/demos/animated-bar/animated-bar.md
@@ -1,5 +1,5 @@
 ##### Animated Bar Chart
 Awesome example from [Peter Cook](https://github.com/animateddata)
 
-Blog Post [Here](https://frontendcharts.com/react-move-barchart/)
+Blog Post [Here](https://www.createwithdata.com/react-move-bar-chart)
 {{demo='pages/demos/animated-bar/Example1.js'}}


### PR DESCRIPTION
I don't know the past page but I guess this is it...

- [x] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

