### PR TITLE
NodeGroup Add generic type from incoming data 

### DIFF
--- a/src/NodeGroup/index.d.ts
+++ b/src/NodeGroup/index.d.ts
@@ -1,17 +1,19 @@
-import * as React from "react";
+import * as React from 'react'
 import { HashMap, GetInterpolator } from '..'
 
-export interface INodeGroupProps {
-  data: Array<any>;
-  keyAccessor: (data: any, index: number) => string | number;
-  interpolation?: GetInterpolator;
-  start: (data: any, index: number) => HashMap;
-  enter?: (data: any, index: number) => (HashMap | Array<HashMap>);
-  update?: (data: any, index: number) => (HashMap | Array<HashMap>);
-  leave?: (data: any, index: number) => (HashMap | Array<HashMap>);
-  children: (nodes: Array<any>) => React.ReactElement<any>;
+export interface INodeGroupProps<T> {
+  data: Array<T>
+  keyAccessor: (data: T, index: number) => string | number
+  interpolation?: GetInterpolator
+  start: (data: T, index: number) => HashMap
+  enter?: (data: T, index: number) => HashMap | Array<HashMap>
+  update?: (data: T, index: number) => HashMap | Array<HashMap>
+  leave?: (data: T, index: number) => HashMap | Array<HashMap>
+  children: (nodes: Array<any>) => React.ReactElement<any>
 }
 
-export declare class INodeGroup extends React.Component<INodeGroupProps> { }
+export declare class INodeGroup<T> extends React.Component<
+  INodeGroupProps<T>
+> {}
 
 export default INodeGroup

--- a/src/NodeGroup/index.d.ts
+++ b/src/NodeGroup/index.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import * as React from "react"
 import { HashMap, GetInterpolator } from '..'
 
 export interface INodeGroupProps<T> {


### PR DESCRIPTION
This PR allows typescript users to directly have the type of the incoming data array inferred in all the following functions:
keyAccessor, start, enter, update and leave.
If this PR is accepted, nothing will change from the user's perspective except that they will enjoy code completion where they might expect it to be.